### PR TITLE
omit multiple keys by listing them as arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,10 @@ module.exports = function omitDeepLodash(input, props) {
     return _.omit(o, props);
   }
 
+  if (arguments.length > 2) {
+    props = Array.prototype.slice.call(arguments).slice(1);
+  }
+
   if (typeof input === "undefined") {
     return {};
   }

--- a/test.js
+++ b/test.js
@@ -23,6 +23,15 @@ describe(".omitDeep()", () => {
     o.should.eql({a: "a", c: {e: {g: {c: "c"}}}});
   });
 
+  it("should recursively omit multiple keys, by listing them as arguments", () => {
+    const o = omitDeep({
+      a: "a",
+      b: "b",
+      c: {b: "b", d: "d", e: {b: "b", f: "f", g: {b: "b", c: "c"}}}
+    }, "b", "d", "f");
+    o.should.eql({a: "a", c: {e: {g: {c: "c"}}}});
+  });
+
   it("should omit the given keys.", () => {
     omitDeep({a: "a", b: "b", c: "c"}, ["a", "c"]).should.eql({b: "b"});
   });


### PR DESCRIPTION
It's nicer to be able to call:

_.omitDeep({a: 'a', b: 'b', c: 'c'}, 'a', 'b')

instead of:

_.omitDeep({a: 'a', b: 'b', c: 'c'}, ['a', 'b'])