### PR TITLE
Check objects with isPlainObject

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ const _ = require("lodash");
 
 module.exports = function omitDeepLodash(input, props) {
   function omitDeepOnOwnProps(obj) {
-    if (!_.isArray(obj) && !_.isObject(obj)) {
+    if (!_.isArray(obj) && !_.isPlainObject(obj)) {
       return obj;
     }
 


### PR DESCRIPTION
`isObject()` returns true for any object in payload. For example for `Promise` . payload may contain not only POJO from json, but any other data. Using `isObject()` malforms such payloads